### PR TITLE
Add stego ctf tools: exiftool, steghide, binwalk, foremost (#11)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -63,6 +63,10 @@ RUN \
     fcrackzip \
     texlive-full \
     latexmk \
+    exiftool \
+    steghide \
+    binwalk \
+    foremost \
     # patator dependencies
     libmysqlclient-dev \
     # evil-winrm dependencies


### PR DESCRIPTION
CTF usually requires theses tools to solve stego challenges:
exiftool , steghide, binwalk, foremost